### PR TITLE
Fix wrong pluginClass namespace in composer.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ composer.phar
 psalm.xml
 .phpunit.cache/
 coverage/
+add-actions-map.json
+psalm-report.xml
+psalm.xml
 
 # Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ psalm.xml
 coverage/
 add-actions-map.json
 psalm-report.xml
-psalm.xml
 
 # Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   ],
   "extra": {
     "psalm": {
-      "pluginClass": "Plugin"
+      "pluginClass": "Tuncay\\PsalmWpTaint\\Plugin"
     }
   },
   "require": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "tuncay/psalm-wp-taint",
-  "version": "0.0.1-dev",
+  "version": "0.0.2",
   "description": "A psalm plugin that adds stubs for psalm to define custom taint sinks for wordpress projects",
   "type": "psalm-plugin",
   "license": "proprietary",


### PR DESCRIPTION
Namespace for value `pluginClass` in `composer.json` was wrong and therefore lead to Psalm not recognizing the plugin correctly.